### PR TITLE
Fix safe_parse_iso and timer update

### DIFF
--- a/timetracker/app.py
+++ b/timetracker/app.py
@@ -1,17 +1,17 @@
 from flask import Flask, render_template, request, redirect, url_for, session
 from datetime import datetime, timedelta
-from datetime import timezone
 from zoneinfo import ZoneInfo
+from collections import defaultdict
 import os
 import json
 from werkzeug.security import check_password_hash
 from dotenv import load_dotenv
+
+
 def safe_parse_iso(dt_str, tz):
     dt = datetime.fromisoformat(dt_str)
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=tz)
-    return dt.astimezone(tz)
-
     return dt.astimezone(tz)
 
 
@@ -135,9 +135,6 @@ def stop():
         data['start_time'] = None
         save_json(TRACK_FILE, data)
     return redirect(url_for('index'))
-from collections import defaultdict
-from datetime import datetime
-from zoneinfo import ZoneInfo
 
 @app.route('/history')
 def history():

--- a/timetracker/templates/index.html
+++ b/timetracker/templates/index.html
@@ -5,9 +5,11 @@
     <title>Uhrensohn</title>
     <link rel="stylesheet" href="/static/style.css">
     <script>
-        let startTime = "{{ start_dt_iso }}";
+        const startTime = "{{ start_dt_iso }}";
 
         function updateElapsed() {
+            if (!startTime) return;
+
             const start = new Date(startTime);
             const now = new Date();
             const diffMs = now - start;
@@ -19,10 +21,15 @@
             const mins = String(Math.floor((totalSeconds % 3600) / 60)).padStart(2, '0');
             const secs = String(totalSeconds % 60).padStart(2, '0');
 
-            document.getElementById('elapsed').textContent = `${hrs}:${mins}:${secs}`;
+            const el = document.getElementById('elapsed');
+            if (el) {
+                el.textContent = `${hrs}:${mins}:${secs}`;
+            }
         }
 
-        setInterval(updateElapsed, 1000);
+        if (startTime) {
+            setInterval(updateElapsed, 1000);
+        }
     </script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- clean up duplicate imports and return in `app.py`
- guard elapsed timer JS when no start time

## Testing
- `python -m py_compile timetracker/app.py timetracker/add_user.py`

------
https://chatgpt.com/codex/tasks/task_e_687a01e7d100832dad1a2cd526bf2b54