### PR TITLE
Add logo across pages

### DIFF
--- a/timetracker/static/style.css
+++ b/timetracker/static/style.css
@@ -21,6 +21,7 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 2em;
+  position: relative;
   text-align: center;
 }
 
@@ -66,6 +67,13 @@ input, select {
   padding: 1em;
   border-radius: 8px;
   background-color: rgba(0, 0, 0, 0.05);
+}
+
+.logo {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  height: 50px;
 }
 
 @media (max-width: 600px) {

--- a/timetracker/templates/history.html
+++ b/timetracker/templates/history.html
@@ -8,6 +8,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
+  <img src="{{ url_for('static', filename='uhrensohn-v3.png') }}" alt="Uhrensohn logo" class="logo">
   <div class="container">
     <h1>📜 History</h1>
     <a class="link" href="/">🔙 Back</a>

--- a/timetracker/templates/index.html
+++ b/timetracker/templates/index.html
@@ -33,6 +33,7 @@
     </script>
 </head>
 <body>
+    <img src="{{ url_for('static', filename='uhrensohn-v3.png') }}" alt="Uhrensohn logo" class="logo">
     <div class="container">
         <h1>⏱️ Uhrensohn - AZ-Erfassung</h1>
         <form action="/start" method="post"><button class="button">▶️ Start</button></form>

--- a/timetracker/templates/login.html
+++ b/timetracker/templates/login.html
@@ -7,6 +7,7 @@
     <link rel="icon" href="/static/favicon.ico" type="image/x-icon">
 </head>
 <body>
+    <img src="{{ url_for('static', filename='uhrensohn-v3.png') }}" alt="Uhrensohn logo" class="logo">
     <div class="container">
         <h1>🔐 Login</h1>
         <form method="post">

--- a/timetracker/templates/settings.html
+++ b/timetracker/templates/settings.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
+    <img src="{{ url_for('static', filename='uhrensohn-v3.png') }}" alt="Uhrensohn logo" class="logo">
     <div class="container">
         <h1>⚙️ Settings</h1>
         <form method="post">


### PR DESCRIPTION
## Summary
- integrate the logo image on all HTML pages
- position the logo with a new `.logo` style

## Testing
- `python -m py_compile timetracker/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687a040cb4d8832db020c91a4c40678c