### PR TITLE
Add PDF export for time tracking history

### DIFF
--- a/timetracker/requirements.txt
+++ b/timetracker/requirements.txt
@@ -2,3 +2,4 @@ flask
 pytz
 werkzeug
 dotenv
+fpdf2

--- a/timetracker/templates/history.html
+++ b/timetracker/templates/history.html
@@ -30,6 +30,16 @@
       {% endfor %}
     </div>
 
+    <form action="/export" method="get">
+      <label for="period">Export:</label>
+      <select name="period" id="period">
+        <option value="daily">Daily</option>
+        <option value="weekly">Weekly</option>
+        <option value="monthly">Monthly</option>
+      </select>
+      <button type="submit" class="button">📄 Export PDF</button>
+    </form>
+
     <canvas id="chart" width="400" height="200"></canvas>
   </div>
 


### PR DESCRIPTION
## Summary
- add fpdf2 to requirements
- support PDF export for history entries
- expose `/export` endpoint
- allow choosing time period in history template

## Testing
- `python3 -m py_compile timetracker/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687a0a2ea570832d9b451b7a97fe7b10